### PR TITLE
BUGFIX-RELEASE: wait to set up event emitter until calling /process

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,11 @@ governing permissions and limitations under the License.
 
 const { AssetCompute } = require("./lib/assetcompute");
 const { AssetComputeEventEmitter } = require("./lib/eventemitter");
-const { createAssetComputeClient } = require("./lib/client");
+const { createAssetComputeClient, AssetComputeClient } = require("./lib/client");
 
 module.exports = {
     AssetCompute,
     AssetComputeEventEmitter,
-    createAssetComputeClient
+    createAssetComputeClient,
+    AssetComputeClient
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -185,7 +185,7 @@ class AssetComputeClient extends EventEmitter {
 
         if (this.eventEmitter) {
             await this.eventEmitter.close();
-            this.eventEmitter = undefined; // new journal, must reset eventEmitter
+            this.eventEmitter = null; // new journal, must reset eventEmitter
         }
         return response;
     }
@@ -246,10 +246,11 @@ class AssetComputeClient extends EventEmitter {
      */
     async process(source, renditions, userData) {
         if (!this._registered) {
-            console.log('No journal registered yet.')
             await this.register();
+            const waitTime = process.env.REGISTER_WAIT_TIME_MSEC || DEFAULT_REGISTER_WAIT_TIME_MSEC;
+            console.log(`Registered a new journal. Waiting ${waitTime}s before calling /process`);
             const sleep = require('util').promisify(setTimeout);
-            await sleep(process.env.REGISTER_WAIT_TIME_MSEC || DEFAULT_REGISTER_WAIT_TIME_MSEC);
+            await sleep(waitTime);
         }
 
         if (!this.eventEmitter) {
@@ -364,7 +365,7 @@ class AssetComputeClient extends EventEmitter {
 
         if (this.eventEmitter) {
             await this.eventEmitter.close();
-            this.eventEmitter = undefined; // journal is removed, must stop eventEmitter
+            this.eventEmitter = null; // journal is removed, must stop eventEmitter
         }
         return response;
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -178,15 +178,15 @@ class AssetComputeClient extends EventEmitter {
             await this.initialize();
         }
 
-        if (this.eventEmitter) {
-            await this.eventEmitter.close();
-            this.eventEmitter = undefined; // new journal, must reset eventEmitter
-        }
-
         // Register I/O event type and journal, emit events
         const response = await this.assetCompute.register();
         this.journal = response.journal;
         this._registered = true;
+
+        if (this.eventEmitter) {
+            await this.eventEmitter.close();
+            this.eventEmitter = undefined; // new journal, must reset eventEmitter
+        }
         return response;
     }
 
@@ -280,7 +280,6 @@ class AssetComputeClient extends EventEmitter {
         }
 
 
-
         // assign user data to uniquely identify rendition by index
         // does not modify the incoming renditions
         renditions = renditions.map((rendition, index) => {
@@ -356,7 +355,6 @@ class AssetComputeClient extends EventEmitter {
         });
     }
 
-
     async unregister() {
         if (!this.assetCompute) {
             await this.initialize();
@@ -368,10 +366,8 @@ class AssetComputeClient extends EventEmitter {
             await this.eventEmitter.close();
             this.eventEmitter = undefined; // journal is removed, must stop eventEmitter
         }
-
         return response;
     }
-
 }
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,8 @@ const { AdobeAuth } = require("@adobe/asset-compute-events-client");
 const { AssetCompute } = require("./assetcompute");
 const { AssetComputeEventEmitter } = require("./eventemitter");
 
+const DEFAULT_REGISTER_WAIT_TIME_MSEC = 30000;
+
 function getAssetComputeClientId(event) {
     return event.userData &&
         event.userData.assetComputeClient &&
@@ -176,33 +178,16 @@ class AssetComputeClient extends EventEmitter {
             await this.initialize();
         }
 
+        if (this.eventEmitter) {
+            await this.eventEmitter.close();
+            this.eventEmitter = undefined; // new journal, must reset eventEmitter
+        }
+
         // Register I/O event type and journal, emit events
-        const { journal } = await this.assetCompute.register();
-        const eventEmitter = new AssetComputeEventEmitter({
-            ...this.options,
-            accessToken: this.accessToken,
-            org: this.integration.technicalAccount.org,
-            journal
-        });
-
-        this.eventEmitter = eventEmitter;
-
-        // event forwarding
-        const self = this;
-        this.eventEmitter.on('rendition_created', event => {
-            if (getAssetComputeClientId(event) === self.id) {
-                completePendingRendition(self);
-                self.emit("rendition_created", event);
-            }
-        });
-        this.eventEmitter.on('rendition_failed', event => {
-            if (getAssetComputeClientId(event) === self.id) {
-                completePendingRendition(self);
-                self.emit("rendition_failed", event);
-            }
-        });
-        this.eventEmitter.on('error', error => self.emit("error", error));
+        const response = await this.assetCompute.register();
+        this.journal = response.journal;
         this._registered = true;
+        return response;
     }
 
     /**
@@ -261,8 +246,41 @@ class AssetComputeClient extends EventEmitter {
      */
     async process(source, renditions, userData) {
         if (!this._registered) {
+            console.log('No journal registered yet.')
             await this.register();
+            const sleep = require('util').promisify(setTimeout);
+            await sleep(process.env.REGISTER_WAIT_TIME_MSEC || DEFAULT_REGISTER_WAIT_TIME_MSEC);
         }
+
+        if (!this.eventEmitter) {
+            const eventEmitter = new AssetComputeEventEmitter({
+                ...this.options,
+                accessToken: this.accessToken,
+                org: this.integration.technicalAccount.org,
+                journal: this.journal
+            });
+
+            this.eventEmitter = eventEmitter;
+
+            // event forwarding
+            const self = this;
+            this.eventEmitter.on('rendition_created', event => {
+                if (getAssetComputeClientId(event) === self.id) {
+                    completePendingRendition(self);
+                    self.emit("rendition_created", event);
+                }
+            });
+            this.eventEmitter.on('rendition_failed', event => {
+                if (getAssetComputeClientId(event) === self.id) {
+                    completePendingRendition(self);
+                    self.emit("rendition_failed", event);
+                }
+            });
+            this.eventEmitter.on('error', error => self.emit("error", error));
+        }
+
+
+
         // assign user data to uniquely identify rendition by index
         // does not modify the incoming renditions
         renditions = renditions.map((rendition, index) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -363,6 +363,12 @@ class AssetComputeClient extends EventEmitter {
         }
         const response = await this.assetCompute.unregister();
         this._registered = false; // wait until successful unregister to set registered variable
+
+        if (this.eventEmitter) {
+            await this.eventEmitter.close();
+            this.eventEmitter = undefined; // journal is removed, must stop eventEmitter
+        }
+
         return response;
     }
 

--- a/test/assetcompute.test.js
+++ b/test/assetcompute.test.js
@@ -79,7 +79,8 @@ describe( 'assetcompute.js tests', () => {
 		assert.strictEqual(response.requestId, requestId);
 	});
 
-	it('should fail call asset compute /unregister before calling /register', async function() {
+	
+it('should fail call asset compute /unregister before calling /register', async function() {
 		const { AssetCompute } = require('../lib/assetcompute');
 		const options = {
 			accessToken: 'accessToken',
@@ -103,4 +104,38 @@ describe( 'assetcompute.js tests', () => {
 		}
 	});
 
+
+	it('should fail calling /process', async function() {
+		const { AssetCompute } = require('../lib/assetcompute');
+		const options = {
+			accessToken: 'accessToken',
+			org: 'org',
+			apiKey: 'apiKey'
+
+		}
+		const requestId = '1234567890';
+		nock('https://asset-compute.adobe.io')
+			.post('/process')
+			.reply(401,{
+				'ok': false,
+				'requestId': requestId,
+				'message':'unauthorized'
+			})
+
+		const assetCompute = new AssetCompute(options);
+		try {
+			await assetCompute.process({
+				url: 'https://example.com/dog.jpg'
+			},
+			[
+				{
+					name: 'rendition.jpg',
+					fmt: 'jpg'
+				}
+			]);
+			assert.fail('Should have failed')
+		} catch (e) {
+			assert.ok(e.message.includes('401'));
+		}
+	});
 })

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -53,6 +53,7 @@ describe( 'client.js tests', () => {
                         }
                     };
                 }
+                stop() {}
             }
         });
     });

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -58,6 +58,7 @@ describe( 'client.js tests', () => {
     });
     
     afterEach( () => {
+        delete process.env.REGISTER_WAIT_TIME_MSEC;
         mockRequire.stopAll();
         nock.cleanAll();
     });
@@ -65,7 +66,7 @@ describe( 'client.js tests', () => {
         const { createAssetComputeClient } = require('../lib/client');
         const options = {
             retryOptions: {
-                retryMaxDuration: 2000
+                retryMaxDuration: 1000
             }
         };
         nock('https://asset-compute.adobe.io')
@@ -73,7 +74,7 @@ describe( 'client.js tests', () => {
             .reply(200, {})
 
         const assetComputeClient = await createAssetComputeClient(DEFAULT_INTEGRATION, options);
-        assert.equal(assetComputeClient.assetCompute.retryOptions.retryMaxDuration, 2000);
+        assert.equal(assetComputeClient.assetCompute.retryOptions.retryMaxDuration, 1000);
     });
 
     it('should create asset compute client with ims endpoint in integration', async function() {
@@ -175,6 +176,8 @@ describe( 'client.js tests', () => {
 
     it('should implictely call /register before calling /process', async function() {
         const { AssetComputeClient } = require('../lib/client');
+
+        process.env.REGISTER_WAIT_TIME_MSEC = 200; // no need to wait between register and processing because mocks
 
         nock('https://asset-compute.adobe.io')
             .post('/register')


### PR DESCRIPTION
needed for this [ticket](https://jira.corp.adobe.com/browse/NUI-447)
_added more unit tests and tested on IT tests with `npm link`_

came across this bug when adding register tests to the IT tests. This bug only happened when a new journal was registered so we never came across it in IT tests since all the integrations we use are already registered:
```
(node:78086) UnhandledPromiseRejectionWarning: Error: get journal events failed with 500 Internal Server Error
    at AdobeIOEvents.getEventsFromJournal (/Users/delbick/work/jdelbick/asset-compute-client/node_modules/@adobe/asset-compute-events-client/lib/events.js:409:19)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async AdobeIOEventEmitter.poll (/Users/delbick/work/jdelbick/asset-compute-client/node_modules/@adobe/asset-compute-events-client/lib/eventemitter.js:132:30)
(node:78086) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 9)
(node:78086) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
1. the `eventEmitter` started polling events immediately after calling /register. the `eventEmitter` should not start until /process is called
2. the new journal takes about ~45s max to be usable after registering. Needed to add a sleep function after `this.register()` is implicitly called in `.process`
