### PR TITLE
FEATURE-RELEASE: fail if not registered, remove createAssetComputeClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,41 @@ This function creates a new instance of `AssetComputeClient` and calls `.registe
     }
 ```
 
+### Register
+After setting up the client, it is necessary to call `.register()` once before calling `.process()`.
+
+If the integration already has an I/O Events journal registered, you __still must call register__. The journal url returned from register is necessary for the client to retrieve I/O Events.
+
+If the integration does not have an I/O Events journal registered, make sure to add some wait time after calling `.register()` before calling `.process()`. (It is recommended to wait around ~30 seconds)
+```js
+const assetCompute = new AssetComputeClient(integration);
+await assetCompute.register();
+```
+
+### Unregister
+The unregister method will remove the I/O Events Journal created in `.register()`. It is necessary to call `.register()` again before attempting to use the client after unregistering.
+
+Example usage:
+```js
+const assetCompute = new AssetComputeClient(integration);
+await assetCompute.register();
+await assetCompute.process(..renditions);
+
+// unregister journal
+await assetCompute.unregister();
+
+// call to process will fail, must call `register()` again first
+try {
+    await assetCompute.process(..renditions);
+} catch (e) {
+    // expected error, must call `register()` first
+}
+
+await assetCompute.register();
+sleep(30000); // sleep after registering to give time for journal to set up
+await assetCompute.process(..renditions);
+```
+
 ### @adobe/node-fetch-retry
 Fetch retry options are documented [here](https://github.com/adobe/node-fetch-retry#optional-custom-parameters).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@adobe/asset-compute-client.svg)](https://npmjs.org/package/@adobe/asset-compute-client)
 
+## Overview
 The Asset Compute Client is separated in 3 parts:
 
 - [AssetCompute](lib/assetcompute.js) - A light-weight wrapper around the AssetCompute API.
@@ -16,19 +17,69 @@ AssetComputeClient has the following capabilities:
 - Wait for a single Asset Compute process request to finish (default timeout is 60s)
 - Wait for all Asset Compute process requests to finish (default timeout is 60s)
 
-Example code:
+## Installation
 
+```
+npm i @adobe/asset-compute-client
+```
+
+## Usage
+
+### Using the Class Initialization
+After the client is set up, you must call `.register()` once before the first call to `.process()`.
+
+If the integration does not already have an I/O Events journal registered, it may take some time after calling `.register()` to be able to recieve and send I/O Events so it is recommended to add some wait time before calling `.process()`.
+
+If the integration already has an I/O Events journal registered, it is recommended to not wait before calling `.process()`.
+```javascript
+    const yaml = require("js-yaml");
+    const { AssetComputeClient } = require("@adobe/asset-compute-client");
+    const sleep = require('util').promisify(setTimeout);
+
+
+    const integration = yaml.safeLoad(await fs.readFile("integration.yaml", "utf-8"));
+    const assetCompute = new AssetComputeClient(integration);
+
+    // Call register before first call the process
+    await assetCompute.register();
+
+    // add wait time for events provider to set up
+    await sleep(30000); // 30s
+
+    const { activationId } = await assetCompute.process(
+        "https://presigned-source-url", [
+            {
+                name: "rendition.png",
+                url: "https://presigned-target-url",
+                fmt: "png",
+                wid: 200,
+                hei: 200
+            }
+        ]
+    )
+    const events = await assetCompute.waitActivation(activationId);
+    if (events[0].type === "rendition_created") {
+        // use the rendition
+    } else {
+        // failed to process
+    }
+```
+
+### Using `createAssetComputeClient()` for Initialization
+
+This function creates a new instance of `AssetComputeClient` and calls `.register()` method.
 ```javascript
     const yaml = require("js-yaml");
     const { createAssetComputeClient } = require("@adobe/asset-compute-client");
 
     const integration = yaml.safeLoad(await fs.readFile("integration.yaml", "utf-8"));
-    const assetCompute = new AssetComputeClient(integration);
+    const assetCompute = await createAssetComputeClient(integration);
+    // add wait time if needed
     const { activationId } = await assetCompute.process(
-        "https://source-url", [
+        "https://presigned-source-url", [
             {
                 name: "rendition.png",
-                url: "https://target-url",
+                url: "https://presigned-target-url",
                 fmt: "png",
                 wid: 200,
                 hei: 200

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If the integration already has an I/O Events journal registered, it is recommend
     await assetCompute.register();
 
     // add wait time for events provider to set up
-    await sleep(30000); // 30s
+    await sleep(45000); // 30s
 
     const { activationId } = await assetCompute.process(
         "https://presigned-source-url", [
@@ -65,15 +65,15 @@ If the integration already has an I/O Events journal registered, it is recommend
     }
 ```
 
-### Using `createAssetComputeClient()` for Initialization
+### Using `AssetComputeClient.create()` for Initialization
 
-This function creates a new instance of `AssetComputeClient` and calls `.register()` method.
+This function creates a new instance of `AssetComputeClient` and calls the `.register()` method.
 ```javascript
     const yaml = require("js-yaml");
-    const { createAssetComputeClient } = require("@adobe/asset-compute-client");
+    const { AssetComputeClient } = require("@adobe/asset-compute-client");
 
     const integration = yaml.safeLoad(await fs.readFile("integration.yaml", "utf-8"));
-    const assetCompute = await createAssetComputeClient(integration);
+    const assetCompute = await AssetComputeClient.create(integration);
     // add wait time if needed
     const { activationId } = await assetCompute.process(
         "https://presigned-source-url", [
@@ -99,7 +99,7 @@ After setting up the client, it is necessary to call `.register()` once before c
 
 If the integration already has an I/O Events journal registered, you __still must call register__. The journal url returned from register is necessary for the client to retrieve I/O Events.
 
-If the integration does not have an I/O Events journal registered, make sure to add some wait time after calling `.register()` before calling `.process()`. (It is recommended to wait around ~30 seconds)
+If the integration does not have an I/O Events journal registered, make sure to add some wait time after calling `.register()` before calling `.process()`. (It is recommended to wait around ~45 seconds)
 ```js
 const assetCompute = new AssetComputeClient(integration);
 await assetCompute.register();
@@ -125,7 +125,7 @@ try {
 }
 
 await assetCompute.register();
-sleep(30000); // sleep after registering to give time for journal to set up
+sleep(45000); // sleep after registering to give time for journal to set up
 await assetCompute.process(..renditions);
 ```
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -148,6 +148,20 @@ class AssetComputeClient extends EventEmitter {
     }
 
     /**
+     * Initialize Asset Compute and calls /register
+     */
+    static async create(integration, options) {
+        // validate integration
+        if (!integration || !integration.metascopes || !integration.technicalAccount) {
+            throw Error(`Asset Compute integration details are required`);
+        }
+        const assetComputeClient =  new AssetComputeClient(integration, options);
+        // Register I/O event type and journal
+        await assetComputeClient.register();
+        return assetComputeClient;
+    }
+
+    /**
      * Set up Asset Compute
      */
     async initialize() {
@@ -244,6 +258,7 @@ class AssetComputeClient extends EventEmitter {
      */
     async process(source, renditions, userData) {
         if (!this._registered) {
+            // note: use AssetComputeClient.create() for a simpler way to initialize the client and call register
             throw new Error('Must call register before calling /process');
         }
 
@@ -365,47 +380,7 @@ class AssetComputeClient extends EventEmitter {
     }
 }
 
-/**
- * @typedef {Object} AdobeIdTechnicalAccount
- * @property {String} id Id of the technical account, such as "12345667EDBA435@techacct.adobe.com"
- * @property {String} org Organization id, such as "8765432DEAB65@AdobeOrg"
- * @property {String} clientId Client id (API key) of the technical account, such as "1234-5678-9876-5433"
- * @property {String} clientSecret Client secret of the the technical account
- * @property {String} privateKey Path to the private key file PEM encoded (either this or `privateKeyFile` is required)
- * @property {String} privateKeyFile Private key PEM encoded as string (either this or `privateKey` is required)
- */
-/**
- * @typedef {Object} AssetComputeIntegration
- * @param {String[]} metascopes Metascopes associated with integration
- * @param {String} imsEndpoint IMS end point (defaults to https://ims-na1.adobelogin.com)
- * @param {AdobeIdTechnicalAccount} technicalAccount Technical account created for Asset Compute integration
- */
-/**
- * @typedef {Object} AssetComputeClientOptions
- * @property {String} [apiKey=] Override the API key used to communicate with Asset Compute. Used only on non-production.
- * @property {String} [url=] Asset Compute url (defaults to https://asset-compute.adobe.io)
- * @property {Number} [interval=] Override interval at which to poll I/O events
- * @property {String} [imsEndpoint=] IMS service to authenticate with
- * @property {Object} [retryOptions=] Fetch retry options for `@adobe/node-fetch-retry` See README.md for more information
- */
-/**
- * Create a high-level asset compute client.
- *
- * @param {AssetComputeIntegration} integration Asset Compute Integration
- * @param {AssetComputeClientOptions} [options=] Options provided to the client
- */
-async function createAssetComputeClient(integration, options) {
-    // validate integration
-    if (!integration || !integration.metascopes || !integration.technicalAccount) {
-        throw Error(`Asset Compute integration details are required`);
-    }
-    const assetComputeClient =  new AssetComputeClient(integration, options);
-    // Register I/O event type and journal
-    await assetComputeClient.register();
-    return assetComputeClient;
-}
 
 module.exports = {
-    createAssetComputeClient,
     AssetComputeClient
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,8 +18,6 @@ const { AdobeAuth } = require("@adobe/asset-compute-events-client");
 const { AssetCompute } = require("./assetcompute");
 const { AssetComputeEventEmitter } = require("./eventemitter");
 
-const DEFAULT_REGISTER_WAIT_TIME_MSEC = 30000;
-
 function getAssetComputeClientId(event) {
     return event.userData &&
         event.userData.assetComputeClient &&
@@ -246,11 +244,7 @@ class AssetComputeClient extends EventEmitter {
      */
     async process(source, renditions, userData) {
         if (!this._registered) {
-            await this.register();
-            const waitTime = process.env.REGISTER_WAIT_TIME_MSEC || DEFAULT_REGISTER_WAIT_TIME_MSEC;
-            console.log(`Registered a new journal. Waiting ${waitTime}s before calling /process`);
-            const sleep = require('util').promisify(setTimeout);
-            await sleep(waitTime);
+            throw new Error('Must call register before calling /process');
         }
 
         if (!this.eventEmitter) {
@@ -406,7 +400,7 @@ async function createAssetComputeClient(integration, options) {
         throw Error(`Asset Compute integration details are required`);
     }
     const assetComputeClient =  new AssetComputeClient(integration, options);
-    // Register I/O event type and journal, emit events
+    // Register I/O event type and journal
     await assetComputeClient.register();
     return assetComputeClient;
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -332,8 +332,8 @@ describe( 'client.js tests', () => {
         }
     });
 
-    it('should implicitely call /register using createAssetComputeClient', async function() {
-        const { createAssetComputeClient } = require('../lib/client');
+    it('should implicitely call /register using AssetComputeClient.create()', async function() {
+        const { AssetComputeClient } = require('../lib/client');
 
         nock('https://asset-compute.adobe.io')
             .post('/register')
@@ -349,7 +349,7 @@ describe( 'client.js tests', () => {
                 'requestId': '3214'
             })
 
-        const assetComputeClient = await createAssetComputeClient(DEFAULT_INTEGRATION);
+        const assetComputeClient = await AssetComputeClient.create(DEFAULT_INTEGRATION);
         // process renditions
         const response = await assetComputeClient.process({
                 url: 'https://example.com/dog.jpg'


### PR DESCRIPTION
follow up from this PR: https://github.com/adobe/asset-compute-client/pull/15/files

1. removed wait time from `.process()` and made that up to the client
2. force `.register()` call before first call to `.process()` 
3. `register()` call is necessary because we need journal URL to poll events so even if journal is already registered, we still need to do a call to register. By moving it to the clients responsibility to call `register()` we give them the freedom to decide how long to wait between register and process calls. If client knows the integration already has a journal set up, they know there is no need to wait before calling `.process()`
4. add more information to readme

_note: this does NOT break compatibility because I kept the old behavior of the `createAssetComputeClient`_

_note: tested using npm link with IT tests_