### PR TITLE
readme bug: use requestId to poll events

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If the integration already has an I/O Events journal registered, it is recommend
     // add wait time for events provider to set up
     await sleep(45000); // 30s
 
-    const { activationId } = await assetCompute.process(
+    const { requestId } = await assetCompute.process(
         "https://presigned-source-url", [
             {
                 name: "rendition.png",
@@ -60,7 +60,7 @@ If the integration already has an I/O Events journal registered, it is recommend
             }
         ]
     )
-    const events = await assetCompute.waitActivation(activationId);
+    const events = await assetCompute.waitActivation(requestId);
     if (events[0].type === "rendition_created") {
         // use the rendition
     } else {
@@ -79,7 +79,7 @@ This function creates a new instance of `AssetComputeClient` and calls the `.reg
     const integration = await getIntegrationConfiguration(integrationFilePath[, privateKeyFile]);
     const assetCompute = await AssetComputeClient.create(integration);
     // add wait time if needed
-    const { activationId } = await assetCompute.process(
+    const { requestId } = await assetCompute.process(
         "https://presigned-source-url", [
             {
                 name: "rendition.png",
@@ -90,7 +90,7 @@ This function creates a new instance of `AssetComputeClient` and calls the `.reg
             }
         ]
     )
-    const events = await assetCompute.waitActivation(activationId);
+    const events = await assetCompute.waitActivation(requestId);
     if (events[0].type === "rendition_created") {
         // use the rendition
     } else {


### PR DESCRIPTION
found small bug in readme while updating documentation. `waitActivation` uses `requestId`, not `activationId`: https://github.com/adobe/asset-compute-client/blob/master/lib/client.js#L328

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
