### PR TITLE
api to check if journal ready

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -380,7 +380,7 @@ class AssetComputeClient extends EventEmitter {
         return response;
     }
 
-    async checkEventJornal(journalUrl) {
+    async checkEventJournal(journalUrl) {
         const ioEvents = new AdobeIOEvents({
             accessToken: this.accessToken,
             orgId: this.integration.technicalAccount.org

--- a/lib/client.js
+++ b/lib/client.js
@@ -379,16 +379,15 @@ class AssetComputeClient extends EventEmitter {
         return response;
     }
 
-    async isEventJournalReady(journalUrl) {
+    async isEventJournalReady() {
         const ioEvents = new AdobeIOEvents({
             accessToken: this.accessToken,
             orgId: this.integration.technicalAccount.org
         });
         try {
-            await ioEvents.getEventsFromJournal(journalUrl);
+            await ioEvents.getEventsFromJournal(this.journal);
             return true;
-        } catch(e) {
-            console.log(e);
+        } catch(e) { // eslint-disable-line no-unused-vars
             return false;
         }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ const uuid = require("uuid/v1");
 const { AdobeAuth } = require("@adobe/asset-compute-events-client");
 const { AssetCompute } = require("./assetcompute");
 const { AssetComputeEventEmitter } = require("./eventemitter");
+const { AdobeIOEvents } = require("@adobe/asset-compute-events-client");
 
 function getAssetComputeClientId(event) {
     return event.userData &&
@@ -377,6 +378,19 @@ class AssetComputeClient extends EventEmitter {
             this.eventEmitter = null; // journal is removed, must stop eventEmitter
         }
         return response;
+    }
+
+    async checkEventJornal(journalUrl) {
+        const ioEvents = new AdobeIOEvents({
+            accessToken: this.accessToken,
+            orgId: this.integration.technicalAccount.org
+        });
+        try {
+            await ioEvents.getEventsFromJournal(journalUrl);
+        } catch(error) {
+            console.error(error);
+            throw error;
+        }
     }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -379,12 +379,18 @@ class AssetComputeClient extends EventEmitter {
         return response;
     }
 
-    async checkEventJournal(journalUrl) {
+    async isEventJournalReady(journalUrl) {
         const ioEvents = new AdobeIOEvents({
             accessToken: this.accessToken,
             orgId: this.integration.technicalAccount.org
         });
-        await ioEvents.getEventsFromJournal(journalUrl);
+        try {
+            await ioEvents.getEventsFromJournal(journalUrl);
+            return true;
+        } catch(e) {
+            console.log(e);
+            return false;
+        }
     }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,10 +14,9 @@
 
 const EventEmitter = require("events");
 const uuid = require("uuid/v1");
-const { AdobeAuth } = require("@adobe/asset-compute-events-client");
+const { AdobeAuth, AdobeIOEvents } = require("@adobe/asset-compute-events-client");
 const { AssetCompute } = require("./assetcompute");
 const { AssetComputeEventEmitter } = require("./eventemitter");
-const { AdobeIOEvents } = require("@adobe/asset-compute-events-client");
 
 function getAssetComputeClientId(event) {
     return event.userData &&
@@ -385,15 +384,9 @@ class AssetComputeClient extends EventEmitter {
             accessToken: this.accessToken,
             orgId: this.integration.technicalAccount.org
         });
-        try {
-            await ioEvents.getEventsFromJournal(journalUrl);
-        } catch(error) {
-            console.error(error);
-            throw error;
-        }
+        await ioEvents.getEventsFromJournal(journalUrl);
     }
 }
-
 
 module.exports = {
     AssetComputeClient

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -47,9 +47,13 @@ describe('client.js tests', () => {
             AdobeIOEvents: class AdobeIOEventsMock { 
                 async getEventsFromJournal(url) {
                     if(url === 'JOURNAL_NOT_READY') {
-                        throw Error('504');
+                        throw Error('get journal events failed with 500 Internal server error');
                     } else {
-                        return 'JOURNAL_READY';
+                        return {
+                            event: {
+                                type: 'rendition_created'
+                            }
+                        };
                     }
                 }
             },
@@ -461,18 +465,20 @@ describe('client.js tests', () => {
 
     it('should throw error if event provider journal is not ready', async function () {
         const { AssetComputeClient } = require('../lib/client');
-        const journalUrl = 'JOURNAL_NOT_READY';
+        // const journalUrl = 'JOURNAL_NOT_READY';
         const assetComputeClient = new AssetComputeClient(DEFAULT_INTEGRATION);
-        const isReady = await assetComputeClient.isEventJournalReady(journalUrl);
+        assetComputeClient.journal = 'JOURNAL_NOT_READY';
+        const isReady = await assetComputeClient.isEventJournalReady();
         assert.ok(!isReady);
         await assetComputeClient.close();
     });
 
     it('should return valid event if provider ready', async function () {
         const { AssetComputeClient } = require('../lib/client');
-        const journalUrl = 'JOURNAL_READY';
+        // const journalUrl = 'JOURNAL_READY';
         const assetComputeClient = new AssetComputeClient(DEFAULT_INTEGRATION);
-        const isReady = await assetComputeClient.isEventJournalReady(journalUrl);
+        assetComputeClient.journal = 'JOURNAL_READY';
+        const isReady = await assetComputeClient.isEventJournalReady();
         assert.ok(isReady);
         await assetComputeClient.close();
     });

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -463,12 +463,8 @@ describe('client.js tests', () => {
         const { AssetComputeClient } = require('../lib/client');
         const journalUrl = 'JOURNAL_NOT_READY';
         const assetComputeClient = new AssetComputeClient(DEFAULT_INTEGRATION);
-        try {
-            await assetComputeClient.checkEventJournal(journalUrl);
-        } catch(e) {
-            console.log(e);
-            assert.ok(e.message.includes('504'));
-        }
+        const isReady = await assetComputeClient.isEventJournalReady(journalUrl);
+        assert.ok(!isReady);
         await assetComputeClient.close();
     });
 
@@ -476,13 +472,8 @@ describe('client.js tests', () => {
         const { AssetComputeClient } = require('../lib/client');
         const journalUrl = 'JOURNAL_READY';
         const assetComputeClient = new AssetComputeClient(DEFAULT_INTEGRATION);
-        try {
-            await assetComputeClient.checkEventJournal(journalUrl);
-            assert.ok('checkEventJournal call successful');
-        } catch(e) {
-            console.log(e);
-            assert.ok(e.message.includes('504'));
-        }
+        const isReady = await assetComputeClient.isEventJournalReady(journalUrl);
+        assert.ok(isReady);
         await assetComputeClient.close();
     });
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -44,7 +44,15 @@ describe('client.js tests', () => {
                     return '123456';
                 }
             },
-            AdobeIOEvents: class AdobeIOEventsMock { },
+            AdobeIOEvents: class AdobeIOEventsMock { 
+                async getEventsFromJournal(url) {
+                    if(url === 'JOURNAL_NOT_READY') {
+                        throw Error('504');
+                    } else {
+                        return 'JOURNAL_READY';
+                    }
+                }
+            },
             AdobeIOEventEmitter: class AdobeIOEventEmitterMock {
                 on() {
                     return {
@@ -448,6 +456,33 @@ describe('client.js tests', () => {
         ]);
         assert.ok(assetComputeClient._registered);
         assert.strictEqual(response.requestId, '3214');
+        await assetComputeClient.close();
+    });
+
+    it('should throw error if event provider journal is not ready', async function () {
+        const { AssetComputeClient } = require('../lib/client');
+        const journalUrl = 'JOURNAL_NOT_READY';
+        const assetComputeClient = new AssetComputeClient(DEFAULT_INTEGRATION);
+        try {
+            await assetComputeClient.checkEventJournal(journalUrl);
+        } catch(e) {
+            console.log(e);
+            assert.ok(e.message.includes('504'));
+        }
+        await assetComputeClient.close();
+    });
+
+    it('should return valid event if provider ready', async function () {
+        const { AssetComputeClient } = require('../lib/client');
+        const journalUrl = 'JOURNAL_READY';
+        const assetComputeClient = new AssetComputeClient(DEFAULT_INTEGRATION);
+        try {
+            await assetComputeClient.checkEventJournal(journalUrl);
+            assert.ok('checkEventJournal call successful');
+        } catch(e) {
+            console.log(e);
+            assert.ok(e.message.includes('504'));
+        }
         await assetComputeClient.close();
     });
 


### PR DESCRIPTION
## Description

Add a new api to check if event provider journal is ready
Changes:
- Add new API
- added tests

Fixes:
[NUI-609](https://jira.corp.adobe.com/browse/NUI-609) devtool waits approx. 45s to 60s after very first call to /register


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
